### PR TITLE
fix: update download url to support new link format

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -3,6 +3,39 @@ function unify_version {
   printf "%03d%03d%03d" $(echo "$1"| sed -e 's/-rc[0-9]//' | tr '.' ' ');
 }
 
+# calculate linux distribution tag to match:
+# https://www.mongodb.com/try/download/community-edition/releases/archive
+function get_distro_tag() {
+  if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+      ubuntu)
+        echo "ubuntu${VERSION_ID//./}"
+        ;;
+      debian)
+        echo "debian${VERSION_ID%%.*}"
+        ;;
+      amzn|amazon)
+        echo "amazon${VERSION_ID%%.*}"
+        ;;
+      centos)
+        echo "rhel${VERSION_ID%%.*}0"
+        ;;
+      rhel)
+        echo "rhel${VERSION_ID%%.*}0"
+        ;;
+      suse)
+        echo "suse${VERSION_ID%%.*}"
+        ;;
+      *)
+        echo "$ID${VERSION_ID}"
+        ;;
+    esac
+  else
+    echo "unknown"
+  fi
+}
+
 install_mongo() {
   local install_type=$1
   local version=$2
@@ -15,11 +48,22 @@ install_mongo() {
   local download_url=""
 
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="osx"
-  [ "x86_64" = "$(uname -m)" ] && arch="x86_64" || [ "arm64" = "$(uname -m)" ] && arch="arm64" || arch="i686"
+  if [ "x86_64" = "$(uname -m)" ]; then
+    arch="x86_64"
+  elif [ "arm64" = "$(uname -m)" ]; then
+    arch="arm64"
+  else
+    arch="i686"
+  fi
   [ "linux" = "${platform}" ] && tempdir=$(mktemp -d asdf-mongodb.XXXX) || tempdir=$(mktemp -dt asdf-mongodb.XXXX)
 
   if [[ "linux" = "${platform}" ]]; then
-    filename="mongodb-linux-${arch}-${version}.tgz"
+    local tag="$(get_distro_tag)"
+    # We also need to re-write the arch for arm64 to aarch64
+    if [[ "arm64" == "${arch}" ]]; then
+      arch="aarch64"
+    fi
+    filename="mongodb-linux-${arch}-${tag}-${version}.tgz"
   else
     if [[ "$(unify_version "$version")" > "$(unify_version "5.0.21")" ]]; then
       filename="mongodb-macos-${arch}-${version}.tgz"


### PR DESCRIPTION
It seems that the mongodb download urls have changed syntax a bit; see [examples](https://www.mongodb.com/try/download/community-edition/releases/archive).

Should fix issue: https://github.com/mise-plugins/mise-mongodb/issues/1

This PR updates how the download link is constructed to attempt to account for distribution and to correct linux architecture which was showing up as `arm64` on an `x86_64` machine but really should be considered `aarch64` for the purposes of downloading.

A drawback to this is that mongodb has not published binaries for all mongo versions and distributions... For example ubuntu LTS 24.04, can only use mongo >= 8.x.x . That said, the alternative was no linux support at all. So I'll take it.  

Tested on osx and ubuntu 24.04.